### PR TITLE
Fix: Save value of formwidget #15

### DIFF
--- a/assets/js/sitemap-definitions.js
+++ b/assets/js/sitemap-definitions.js
@@ -49,7 +49,7 @@
             return result
         }
 
-        data.options.data['itemData'] = iterator($items)
+        data.options.data['Definition'] = {items: iterator($items)};
     }
 
     $(document).ready(function(){

--- a/formwidgets/SitemapItems.php
+++ b/formwidgets/SitemapItems.php
@@ -75,14 +75,6 @@ class SitemapItems extends FormWidgetBase
         $this->addJs('js/sitemap-items-editor.js', 'core');
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function getSaveValue($value)
-    {
-        return post('itemData');
-    }
-
     //
     // Methods for the internal use
     //


### PR DESCRIPTION
This fixes issue #15.

The JS which handles the form submission is assigning the added form fields to the wrong key in the post array.
This PR updates the JS, so that the saved values correspond to the update structure of Winter CMS.

Also, the getSaveValue of the formwidget class is not needed anymore since using the default behaviour of the form field is fine in this case.