### PR TITLE
Add update.htm file for sitemap definitions controller

### DIFF
--- a/controllers/definitions/update.htm
+++ b/controllers/definitions/update.htm
@@ -1,0 +1,51 @@
+<?php Block::put('breadcrumb') ?>
+    <ul>
+        <li><a href="<?= Backend::url('winter/sitemap') ?>"><?= e(trans('winter.sitemap::lang.plugin.name')); ?></a></li>
+        <li><?= e(trans('backend::lang.form.update_title', ['name' => $this->pageTitle])); ?></li>
+    </ul>
+<?php Block::endPut() ?>
+
+<?php if (!$this->fatalError): ?>
+
+    <?= Form::open(['class' => 'layout', 'id' => 'sitemapForm']) ?>
+
+        <div class="layout-row">
+            <?= $this->formRender() ?>
+        </div>
+
+        <div class="padded-container">
+            <div class="form-buttons">
+                <div class="loading-indicator-container">
+                    <button
+                        type="submit"
+                        data-request="onSave"
+                        data-request-data="redirect:0"
+                        data-hotkey="ctrl+s, cmd+s"
+                        data-load-indicator="<?= e(trans('winter.sitemap::lang.item.save_definition')) ?>"
+                        class="btn btn-primary">
+                        <?= e(trans('backend::lang.form.save')) ?>
+                    </button>
+                    <button
+                        type="button"
+                        class="oc-icon-trash-o btn-icon danger pull-right"
+                        data-request="onDelete"
+                        data-load-indicator="<?= e(trans('winter.sitemap::lang.item.load_indicator')) ?>"
+                        data-request-confirm="<?= e(trans('winter.sitemap::lang.item.empty_confirm')) ?>">
+                    </button>
+                    <span class="btn-text">
+                        <?= e(trans('backend::lang.form.or')) ?> <a href="<?= Backend::url('winter/sitemap/definitions') ?>"><?= e(trans('backend::lang.form.cancel')) ?></a>
+                    </span>
+                </div>
+            </div>
+        </div>
+
+    <?= Form::close() ?>
+
+<?php else: ?>
+
+    <div class="padded-container">
+        <p class="flash-message static error"><?= e(trans($this->fatalError)) ?></p>
+        <p><a href="<?= Backend::url('system/settings') ?>" class="btn btn-default"><?= e(trans('system::lang.settings.return')) ?></a></p>
+    </div>
+
+<?php endif ?>


### PR DESCRIPTION
The `update.htm` file is neede to correctly set form ID to `sitemapForm` which is expected by `plugins/winter/sitemap/assets/js/sitemap-definitions.js` script.

Without this, the sitemap items are not saved (an empty array is handed over).

*This is a little modified version of original `update.htm` file that has been removed in v2.2.0.*
