### PR TITLE
Make priority and changefreq optional

### DIFF
--- a/classes/definitionitem/fields.yaml
+++ b/classes/definitionitem/fields.yaml
@@ -32,6 +32,7 @@ fields:
         span: left
         label: winter.sitemap::lang.item.priority
         type: dropdown
+        emptyOption: winter.sitemap::lang.item.omitted
         options:
             '0.1': '0.1'
             '0.2': '0.2'
@@ -48,6 +49,7 @@ fields:
         span: right
         label: winter.sitemap::lang.item.changefreq
         type: dropdown
+        emptyOption: winter.sitemap::lang.item.omitted
         options:
             always: winter.sitemap::lang.item.always
             hourly: winter.sitemap::lang.item.hourly

--- a/classes/definitionitem/fields.yaml
+++ b/classes/definitionitem/fields.yaml
@@ -34,6 +34,7 @@ fields:
         type: dropdown
         emptyOption: winter.sitemap::lang.item.omitted
         options:
+            '0.0': '0.0'
             '0.1': '0.1'
             '0.2': '0.2'
             '0.3': '0.3'

--- a/formwidgets/SitemapItems.php
+++ b/formwidgets/SitemapItems.php
@@ -49,16 +49,9 @@ class SitemapItems extends FormWidgetBase
     {
         $sitemapItem = new SitemapItem;
 
+        $this->vars['emptyItem'] = $sitemapItem;
         $this->vars['itemProperties'] = json_encode($sitemapItem->fillable);
         $this->vars['items'] = $this->model->items;
-
-        $emptyItem = new SitemapItem;
-        $emptyItem->type = 'url';
-        $emptyItem->url = '/';
-        $emptyItem->changefreq = 'always';
-        $emptyItem->priority = '0.5';
-
-        $this->vars['emptyItem'] = $emptyItem;
 
         $widgetConfig = $this->makeConfig('$/winter/sitemap/classes/definitionitem/fields.yaml');
         $widgetConfig->model = $sitemapItem;

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -13,6 +13,7 @@ return [
         'location' => 'Location:',
         'priority' => 'Priority',
         'changefreq' => 'Change frequency',
+        'omitted' => 'Omitted',
         'always' => 'always',
         'hourly' => 'hourly',
         'daily' => 'daily',
@@ -45,5 +46,5 @@ return [
     ],
     'definition' => [
         'not_found' => 'No sitemap definition was found. Try creating one first.'
-    ]
+    ],
 ];

--- a/models/Definition.php
+++ b/models/Definition.php
@@ -240,8 +240,12 @@ class Definition extends Model
 
         $urlElement->appendChild($xml->createElement('loc', $itemInfo['url']));
         $urlElement->appendChild($xml->createElement('lastmod', $itemInfo['lastModified']));
-        $urlElement->appendChild($xml->createElement('changefreq', $item->changefreq));
-        $urlElement->appendChild($xml->createElement('priority', $item->priority));
+        if (!empty($item->changefreq)) {
+            $urlElement->appendChild($xml->createElement('changefreq', $item->changefreq));
+        }
+        if (!empty($item->priority)) {
+            $urlElement->appendChild($xml->createElement('priority', $item->priority));
+        }
 
         $urlSet->appendChild($urlElement);
 

--- a/models/Definition.php
+++ b/models/Definition.php
@@ -243,7 +243,7 @@ class Definition extends Model
         if (!empty($item->changefreq)) {
             $urlElement->appendChild($xml->createElement('changefreq', $item->changefreq));
         }
-        if (!empty($item->priority)) {
+        if (!is_numeric($item->priority)) {
             $urlElement->appendChild($xml->createElement('priority', $item->priority));
         }
 

--- a/models/Definition.php
+++ b/models/Definition.php
@@ -243,7 +243,7 @@ class Definition extends Model
         if (!empty($item->changefreq)) {
             $urlElement->appendChild($xml->createElement('changefreq', $item->changefreq));
         }
-        if (!is_numeric($item->priority)) {
+        if (is_numeric($item->priority)) {
             $urlElement->appendChild($xml->createElement('priority', $item->priority));
         }
 


### PR DESCRIPTION
Add an "Omitted" empty option to the `priority` and `changefreq` dropdowns in the definition item fields, so these fields can be left optional, since Google has not considered them for quite some time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Priority and change frequency fields now include an explicit "Omitted" option so users can mark them as intentionally excluded.
* **Bug Fixes / Improvements**
  * Sitemap generation only emits changefreq and priority tags when meaningful values are present, preventing empty or unintended tags.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wintercms/wn-sitemap-plugin/pull/27)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->